### PR TITLE
Cpm2user31

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -80,27 +80,28 @@ fsck.test:	fsck.cpm
 		-./fsck.cpm -f pcw -n badfs/label
 
 install:	all
-		[ -d $(MANDIR)/man1 ] || $(INSTALL) -m 755 -d $(MANDIR)/man1
-		[ -d $(MANDIR)/man5 ] || $(INSTALL) -m 755 -d $(MANDIR)/man5
-		[ -d $(BINDIR) ] || $(INSTALL) -m 755 -d $(BINDIR)
-		$(INSTALL) -m 755 cpmls $(BINDIR)/cpmls
-		$(INSTALL) -m 755 cpmcp $(BINDIR)/cpmcp
-		$(INSTALL) -m 755 cpmrm $(BINDIR)/cpmrm
-		$(INSTALL) -m 755 cpmchmod $(BINDIR)/cpmchmod
-		$(INSTALL) -m 755 cpmchattr $(BINDIR)/cpmchattr
-		$(INSTALL) -m 755 mkfs.cpm $(BINDIR)/mkfs.cpm
-		$(INSTALL) -m 755 fsck.cpm $(BINDIR)/fsck.cpm
-		[ "$(FSED_CPM)" == '' ] || $(INSTALL) -m 755 fsed.cpm $(BINDIR)/fsed.cpm
-		$(INSTALL_DATA) diskdefs @datarootdir@/diskdefs
-		$(INSTALL_DATA) cpmls.1 $(MANDIR)/man1/cpmls.1
-		$(INSTALL_DATA) cpmcp.1 $(MANDIR)/man1/cpmcp.1
-		$(INSTALL_DATA) cpmrm.1 $(MANDIR)/man1/cpmrm.1
-		$(INSTALL_DATA) cpmchmod.1 $(MANDIR)/man1/cpmchmod.1
-		$(INSTALL_DATA) cpmchattr.1 $(MANDIR)/man1/cpmchattr.1
-		$(INSTALL_DATA) mkfs.cpm.1 $(MANDIR)/man1/mkfs.cpm.1
-		$(INSTALL_DATA) fsck.cpm.1 $(MANDIR)/man1/fsck.cpm.1
-		$(INSTALL_DATA) fsed.cpm.1 $(MANDIR)/man1/fsed.cpm.1
-		$(INSTALL_DATA) cpm.5 $(MANDIR)/man5/cpm.5
+		[ -d $(DESTDIR)$(MANDIR)/man1 ] || $(INSTALL) -m 755 -d $(DESTDIR)$(MANDIR)/man1
+		[ -d $(DESTDIR)$(MANDIR)/man5 ] || $(INSTALL) -m 755 -d $(DESTDIR)$(MANDIR)/man5
+		[ -d $(DESTDIR)$(BINDIR) ] || $(INSTALL) -m 755 -d $(DESTDIR)$(BINDIR)
+		$(INSTALL) -s -m 755 cpmls $(DESTDIR)$(BINDIR)/cpmls
+		$(INSTALL) -s -m 755 cpmcp $(DESTDIR)$(BINDIR)/cpmcp
+		$(INSTALL) -s -m 755 cpmrm $(DESTDIR)$(BINDIR)/cpmrm
+		$(INSTALL) -s -m 755 cpmchmod $(DESTDIR)$(BINDIR)/cpmchmod
+		$(INSTALL) -s -m 755 cpmchattr $(DESTDIR)$(BINDIR)/cpmchattr
+		$(INSTALL) -s -m 755 mkfs.cpm $(DESTDIR)$(BINDIR)/mkfs.cpm
+		$(INSTALL) -s -m 755 fsck.cpm $(DESTDIR)$(BINDIR)/fsck.cpm
+		[ "$(FSED_CPM)" == '' ] || $(INSTALL) -s -m 755 fsed.cpm $(DESTDIR)$(BINDIR)/fsed.cpm
+		$(INSTALL_DATA) diskdefs $(DESTDIR)@datarootdir@/diskdefs
+		$(INSTALL_DATA) cpmls.1 $(DESTDIR)$(MANDIR)/man1/cpmls.1
+		$(INSTALL_DATA) cpmcp.1 $(DESTDIR)$(MANDIR)/man1/cpmcp.1
+		$(INSTALL_DATA) cpmrm.1 $(DESTDIR)$(MANDIR)/man1/cpmrm.1
+		$(INSTALL_DATA) cpmchmod.1 $(DESTDIR)$(MANDIR)/man1/cpmchmod.1
+		$(INSTALL_DATA) cpmchattr.1 $(DESTDIR)$(MANDIR)/man1/cpmchattr.1
+		$(INSTALL_DATA) mkfs.cpm.1 $(DESTDIR)$(MANDIR)/man1/mkfs.cpm.1
+		$(INSTALL_DATA) fsck.cpm.1 $(DESTDIR)$(MANDIR)/man1/fsck.cpm.1
+		$(INSTALL_DATA) fsed.cpm.1 $(DESTDIR)$(MANDIR)/man1/fsed.cpm.1
+		$(INSTALL_DATA) cpm.5 $(DESTDIR)$(MANDIR)/man5/cpm.5
+		$(INSTALL_DATA) diskdefs.5 $(DESTDIR)$(MANDIR)/man5/diskdefs.5
 
 clean:
 		rm -f *$(OBJEXT)

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
-Changes since 2.19:
+Changes since 2.20:
 
-o  Fixed bug in cpmfs leading to wrongly allocated blocks
+o  rc759 diskdef renamed to rc75x, as it works for the series
+o  diskdefs.5 added
+o  Many disk formats from Larry Kraemer added
+o  Renamed ampdsdd to ampro400d for consistency with libdsk and because
+   ampdsdd very likely was wrong
+o  Check for invalid block size
+o  Output line number for diskdefs errors
+o  Correctly output create or access time for CP/M 3 in cpmls
+o  Spectravideo SVI-728 diskdef added
+o  $DESTDIR support
+o  Correctly handle empty files

--- a/configure
+++ b/configure
@@ -2272,8 +2272,8 @@ IFS=$ac_save_IFS
 case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
-VERSION=2.20
-UPDATED='October 25, 2014'
+VERSION=2.21
+UPDATED='Jan 23, 2019'
 
 DEVICE="posix"
 
@@ -4476,7 +4476,7 @@ eval DATADIR=$datadir
 
 
 
-ac_config_files="$ac_config_files Makefile cpm.5 cpmchattr.1 cpmchmod.1 cpmcp.1 cpmls.1 cpmrm.1 fsck.cpm.1 fsed.cpm.1 mkfs.cpm.1"
+ac_config_files="$ac_config_files Makefile cpm.5 cpmchattr.1 cpmchmod.1 cpmcp.1 cpmls.1 cpmrm.1 fsck.cpm.1 fsed.cpm.1 mkfs.cpm.1 diskdefs.5"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5179,6 +5179,7 @@ do
     "fsck.cpm.1") CONFIG_FILES="$CONFIG_FILES fsck.cpm.1" ;;
     "fsed.cpm.1") CONFIG_FILES="$CONFIG_FILES fsed.cpm.1" ;;
     "mkfs.cpm.1") CONFIG_FILES="$CONFIG_FILES mkfs.cpm.1" ;;
+    "diskdefs.5") CONFIG_FILES="$CONFIG_FILES diskdefs.5" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.in
+++ b/configure.in
@@ -1,8 +1,8 @@
 AC_INIT(cpmfs.c)
 AC_CONFIG_HEADER(config.h)
 AC_CANONICAL_HOST
-VERSION=2.20
-UPDATED='October 25, 2014'
+VERSION=2.21
+UPDATED='Jan 23, 2019'
 
 DEVICE="posix"
 
@@ -125,4 +125,4 @@ AC_SUBST(DISKDEFS)
 AC_SUBST(DEFFORMAT)
 AC_SUBST(FSED_CPM)
 AC_SUBST(UPDATED)
-AC_OUTPUT(Makefile cpm.5 cpmchattr.1 cpmchmod.1 cpmcp.1 cpmls.1 cpmrm.1 fsck.cpm.1 fsed.cpm.1 mkfs.cpm.1 )
+AC_OUTPUT(Makefile cpm.5 cpmchattr.1 cpmchmod.1 cpmcp.1 cpmls.1 cpmrm.1 fsck.cpm.1 fsed.cpm.1 mkfs.cpm.1 diskdefs.5)

--- a/cpm.5
+++ b/cpm.5
@@ -1,7 +1,7 @@
 .\" Believe it or not, reportedly there are nroffs which do not know \(en
 .if n .ds en -
 .if t .ds en \(en
-.TH CPM 5 "October 25, 2014" "CP/M tools" "File formats"
+.TH CPM 5 "Jan 23, 2019" "CP/M tools" "File formats"
 .SH NAME \"{{{roff}}}\"{{{
 cpm \- CP/M disk and file system format
 .\"}}}
@@ -32,7 +32,9 @@ A block is the smallest allocatable storage unit.  CP/M supports block
 sizes of 1024, 2048, 4096, 8192 and 16384 bytes.  Unfortunately, this
 format specification is not stored on the disk and there are lots of
 formats.  Accessing a block is performed by accessing its sectors, which
-are stored with the given software skew.
+are stored with the given software skew.  \fBcpmtools\fP always counts
+sectors starting with 0, as it deals with logical sectors.  CP/M uses physical
+sectors in the skew table, which often start with 1.
 .\"}}}
 .SS "Device areas" \"{{{
 A CP/M disk contains four areas:
@@ -149,6 +151,8 @@ Rc stores the number of 128 byte records of the last used logical extent.
 Bc stores the number of bytes in the last used record.  The value 0 means
 128 for backward compatibility with CP/M 2.2, which did not support Bc.
 ISX records the number of unused instead of used bytes in Bc.
+This only applies to files with allocated blocks.  For an empty file, no
+block is allocated and Bc 0 has no meaning.
 .\"}}}
 .LP
 .\"{{{ Al     = allocated blocks

--- a/cpm.5.in
+++ b/cpm.5.in
@@ -32,7 +32,9 @@ A block is the smallest allocatable storage unit.  CP/M supports block
 sizes of 1024, 2048, 4096, 8192 and 16384 bytes.  Unfortunately, this
 format specification is not stored on the disk and there are lots of
 formats.  Accessing a block is performed by accessing its sectors, which
-are stored with the given software skew.
+are stored with the given software skew.  \fBcpmtools\fP always counts
+sectors starting with 0, as it deals with logical sectors.  CP/M uses physical
+sectors in the skew table, which often start with 1.
 .\"}}}
 .SS "Device areas" \"{{{
 A CP/M disk contains four areas:
@@ -149,6 +151,8 @@ Rc stores the number of 128 byte records of the last used logical extent.
 Bc stores the number of bytes in the last used record.  The value 0 means
 128 for backward compatibility with CP/M 2.2, which did not support Bc.
 ISX records the number of unused instead of used bytes in Bc.
+This only applies to files with allocated blocks.  For an empty file, no
+block is allocated and Bc 0 has no meaning.
 .\"}}}
 .LP
 .\"{{{ Al     = allocated blocks

--- a/cpmchattr.1
+++ b/cpmchattr.1
@@ -1,4 +1,4 @@
-.TH CPMCHATTR 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH CPMCHATTR 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME \"{{{roff}}}\"{{{
 cpmchattr \- change file attributes on CP/M files
 .\"}}}

--- a/cpmchmod.1
+++ b/cpmchmod.1
@@ -1,4 +1,4 @@
-.TH CPMCHMOD 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH CPMCHMOD 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME \"{{{roff}}}\"{{{
 cpmchmod \- change file mode on CP/M files
 .\"}}}

--- a/cpmcp.1
+++ b/cpmcp.1
@@ -1,4 +1,4 @@
-.TH CPMCP 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH CPMCP 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME \"{{{roff}}}\"{{{
 cpmcp \- copy files from and to CP/M disks
 .\"}}}

--- a/cpmfs.h
+++ b/cpmfs.h
@@ -144,10 +144,12 @@ struct cpmSuperBlock
   int type;
   int size;
   int extents; /* logical extents per physical extent */
+  int *skewtab;
+  char libdskGeometry[256];
+
   struct PhysDirectoryEntry *dir;
   int alvSize;
   int *alv;
-  int *skewtab;
   int cnotatime;
   char *label;
   size_t labelLength;
@@ -157,7 +159,6 @@ struct cpmSuperBlock
   int dirtyDirectory;
   struct dsDate *ds;
   int dirtyDs;
-  char libdskGeometry[256];
 };
 
 struct cpmStatFS

--- a/cpmfs.h
+++ b/cpmfs.h
@@ -106,7 +106,7 @@ struct cpmStat
 #define CPMFS_DS_DATES   (0x1<<3) /* has datestamper timestamps   */
 #define CPMFS_EXACT_SIZE (0x1<<4) /* has reverse exact file size  */
 
-#define CPMFS_DR22  0
+#define CPMFS_DR22  (CPMFS_HI_USER)
 #define CPMFS_P2DOS (CPMFS_CPM3_DATES|CPMFS_HI_USER)
 #define CPMFS_DR3   (CPMFS_CPM3_DATES|CPMFS_CPM3_OTHER|CPMFS_HI_USER)
 #define CPMFS_ISX   (CPMFS_EXACT_SIZE)

--- a/cpmls.1
+++ b/cpmls.1
@@ -1,4 +1,4 @@
-.TH CPMLS 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH CPMLS 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME \"{{{roff}}}\"{{{
 cpmls \- list sorted contents of directory
 .\"}}}

--- a/cpmls.c
+++ b/cpmls.c
@@ -166,7 +166,8 @@ static void old3dir(char **dirent, int entries, struct cpmInode *ino)
           {
             if (user) putchar('\n');
             printf("Directory For Drive A:  User %2.1d\n\n",user);
-            printf("    Name     Bytes   Recs   Attributes   Prot      Update          Create\n");
+            printf("    Name     Bytes   Recs   Attributes   Prot      Update          %s\n",
+		ino->sb->cnotatime ? "Create" : "Access");
             printf("------------ ------ ------ ------------ ------ --------------  --------------\n\n");
           }
           announce=2;
@@ -199,10 +200,15 @@ static void old3dir(char **dirent, int entries, struct cpmInode *ino)
             tmp=localtime(&statbuf.mtime);
             printf("%02d/%02d/%02d %02d:%02d  ",tmp->tm_mon+1,tmp->tm_mday,tmp->tm_year%100,tmp->tm_hour,tmp->tm_min);
           }
-          else if (statbuf.ctime) printf("                ");
-          if (statbuf.ctime)
+          else printf("                ");
+          if (ino->sb->cnotatime && statbuf.ctime)
           {
             tmp=localtime(&statbuf.ctime);
+            printf("%02d/%02d/%02d %02d:%02d",tmp->tm_mon+1,tmp->tm_mday,tmp->tm_year%100,tmp->tm_hour,tmp->tm_min);
+          }
+          else if (!ino->sb->cnotatime && statbuf.atime)
+          {
+            tmp=localtime(&statbuf.atime);
             printf("%02d/%02d/%02d %02d:%02d",tmp->tm_mon+1,tmp->tm_mday,tmp->tm_year%100,tmp->tm_hour,tmp->tm_min);
           }
           putchar('\n');

--- a/cpmrm.1
+++ b/cpmrm.1
@@ -1,4 +1,4 @@
-.TH CPMRM 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH CPMRM 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME \"{{{roff}}}\"{{{
 cpmrm \- remove files on CP/M disks
 .\"}}}

--- a/diskdefs
+++ b/diskdefs
@@ -20,6 +20,17 @@ diskdef 4mb-hd
   os p2dos
 end
 
+diskdef sdcard
+  seclen 512
+  tracks 256
+  sectrk 64
+  blocksize 8192
+  maxdir 256
+  skew 0
+  boottrk 1
+  os 2.2
+end
+
 diskdef pcw
   seclen 512
   tracks 40
@@ -367,12 +378,7 @@ diskdef fdd3000_2
   skew 5
 end
 
-############################
-# GdR/Robotron scp disks
-############################
-
-# robotron PC1715 SCP 185k (40*1* 5,1024 6 OFS 2k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=1024 cyl=40 sect=5 head=1 dtr=1 fm=0
+# Robotron 1715
 diskdef 1715
   seclen 1024
   tracks 40
@@ -384,8 +390,7 @@ diskdef 1715
   os 2.2
 end
 
-# robotron PC1715 SCP3 760k (80*2* 5,1024 8 OFS 4k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=1024 cyl=80 sect=5 head=2 dtr=1 fm=0
+# Robotron 1715 with SCP3
 diskdef 17153
   seclen 1024
   tracks 160
@@ -397,8 +402,7 @@ diskdef 17153
   os 3
 end
 
-# robotron PC1715 SCP 624k (80*2* 16,256 8 OFS 4k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=256 cyl=80 sect=16 head=2 dtr=1 fm=0
+#DDR
 diskdef scp624
   seclen 256
   tracks 160
@@ -406,13 +410,10 @@ diskdef scp624
   blocksize 2048
   maxdir 128
   skew 0
-  boottrk 4
+  boottrk 2
   os 2.2
-  libdsk:format scp640
 end
 
-# robotron PC1715 SCP 640k (80*2* 16,256 0 OFS 4k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=256 cyl=80 sect=16 head=2 dtr=1 fm=0
 diskdef scp640
   seclen 256
   tracks 160
@@ -422,11 +423,8 @@ diskdef scp640
   skew 0
   boottrk 0
   os 2.2
-  libdsk:format scp640
 end
 
-# robotron PC1715 SCP 780k (80*2* 5,1024 8 OFS 4k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=1024 cyl=80 sect=5 head=2 dtr=1 fm=0
 diskdef scp780
   seclen 1024
   tracks 160
@@ -434,13 +432,10 @@ diskdef scp780
   blocksize 2048
   maxdir 128
   skew 0
-  boottrk 4
+  boottrk 2
   os 2.2
-  libdsk:format scp800
 end
 
-# robotron PC1715 SCP 800k (80*2* 5,1024 0 OFS 4k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=1024 cyl=80 sect=5 head=2 dtr=1 fm=0
 diskdef scp800
   seclen 1024
   tracks 160
@@ -450,11 +445,8 @@ diskdef scp800
   skew 0
   boottrk 0
   os 2.2
-  libdsk:format scp800
 end 
 
-# robotron Z9001 800k (80*2* 5,1024 0 OFS 6k DIR) 5.25"
-# setfdprm /dev/fd1 ds dd ssize=1024 cyl=80 sect=5 head=2 dtr=1 fm=0
 diskdef z9001
   seclen 1024
   tracks 160
@@ -512,7 +504,8 @@ diskdef dreamdisk80
   os 2.2
 end
 
-diskdef rc759
+# RC75x series
+diskdef rc75x
   seclen 1024
   tracks 154
   sectrk 8
@@ -785,6 +778,54 @@ diskdef heassdd8
 # DENSITY MFM ,LOW 
 end
 
+# ZEN7  Zenith Z-100 - SSDD 48 tpi 5.25" - 512 x 8
+diskdef zen7
+  seclen 512
+  tracks 40
+  sectrk 8
+  blocksize 1024
+  maxdir 128
+  skew 1
+  boottrk 2
+  os 2.2
+end
+
+# ZEN8  Zenith Z-100 - DSDD 48 tpi 5.25" - 512 x 8
+diskdef zen8
+  seclen 512
+  tracks 80
+  sectrk 8
+  blocksize 2048
+  maxdir 256
+  skew 1
+  boottrk 2
+  os 2.2
+end
+
+# ZEN9  Zenith Z-100 - SSSD 8" - 128 x 26
+diskdef zen9
+  seclen 128
+  tracks 77
+  sectrk 26
+  blocksize 1024
+  maxdir 64
+  skew 6
+  boottrk 2
+  os 2.2
+end
+
+# ZENA  Zenith Z-100 - SSDD 8" - 256 x 26
+diskdef zena
+  seclen 256
+  tracks 77
+  sectrk 26
+  blocksize 2048
+  maxdir 128
+  skew 9
+  boottrk 2
+  os 2.2
+end
+
 # Morrow Designs Micro-Decision         DOUBLE
 # 64k CP/M Vers. 2.2 Rev.2.3            SIDED
 # Copyright '76, '77, '78, '79, '80
@@ -838,38 +879,6 @@ diskdef osb1sssd
 # BSH 4 BLM 15 EXM 1 DSM 45 DRM 63 AL0 080H AL1 0 OFS 3
 end
 
-# BEGIN ampdsdd  Ampro - DSDD 48 tpi 5.25" - 512 x 10
-# Test OK - image size = 409,600, from Don Maslin's archive
-diskdef ampdsdd
-  seclen 1024
-  tracks 80
-  sectrk 5
-  blocksize 2048
-  maxdir 128
-  skew 0
-  boottrk 2
-  os 2.2
-  libdsk:format ampro400d
-# DENSITY MFM ,LOW 
-# BSH 4 BLM 15 EXM 1 DSM 194 DRM 127 AL0 0C0H AL1 0 OFS 2
-end
-
-# BEGIN ampdsdd80  Ampro - DSDD 96 tpi 5.25" - 512 x 10
-# Test OK - image size = 819,200, from Don Maslin's archive
-diskdef ampdsdd80
-  seclen 1024
-  tracks 160
-  sectrk 5
-  blocksize 2048
-  maxdir 128
-  skew 0
-  boottrk 2
-  os 2.2
-  libdsk:format ampro800
-# DENSITY MFM ,LOW 
-# BSH 4 BLM 15 EXM 1 DSM 194 DRM 127 AL0 0C0H AL1 0 OFS 2
-end
-
 # BEGIN altdsdd  Altos - DSDD 5" - 512 x 9
 # Test OK - both CP/M and MP/M - image size = 737,280, from Dave Dunfield
 diskdef altdsdd
@@ -885,6 +894,8 @@ diskdef altdsdd
 # BSH 5 BLM 31 EXM 3 DSM 176 DRM 176 AL0 0C0H AL1 0 OFS 2
 end
 
+# All TRS formats added by Larry Kraemer
+
 # BEGIN trsomsssd  TRS-80 Model 1, Omikron CP/M - SSSD 48 tpi 5.25" - 128 x 18
 # Test OK - image size = 80,640, from TRS-80 Yahoo Group posting
 diskdef trsomsssd
@@ -898,6 +909,304 @@ diskdef trsomsssd
   os 2.2
 # DENSITY FM ,LOW 
 # BSH 3 BLM 7 EXM 0 DSM 71 DRM 63 AL0 0C0H AL1 0 OFS 3
+end
+
+diskdef trsg         #= TRS-80 Model 4,4P Montezuma System 170K - SSDD 48 tpi 5.25"
+  seclen 256         #= Sectors xx,256
+  tracks 40          #= (Cylinders * Sides) = 40*1 = 40
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 18          #= Sectors 18,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsh         #= TRS-80 Model 4,4P Montezuma Data 200K - SSDD 48 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 40          #= (Cylinders * Sides) = 40*1 = 40
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsi         #= TRS-80 Model 4,4P Montezuma System 350K - DSDD 48 tpi 5.25"
+  seclen 256         #= Sectors xx,256
+  tracks 80          #= (Cylinders * Sides) = 40*2 = 80
+#  sides outout       #= Order of Cylinders  = alt, outout, outback
+  sectrk 18          #= Sectors 18,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+#end
+
+diskdef trsj         #= TRS-80 Model 4,4P Montezuma Data 400K - DSDD 48 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 80          #= (Cylinders * Sides) = 40*2 = 80
+#  sides outout       #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsk         #= TRS-80 Model 4,4P Montezuma System 350K - SSDD 96 tpi 5.25"
+  seclen 256         #= Sectors xx,256
+  tracks 80          #= (Cylinders * Sides) = 80*1 = 80
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 18          #= Sectors 18,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsl         #= TRS-80 Model 4,4P Montezuma Data 400K - SSDD 96 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 80          #= (Cylinders * Sides) = 80*1 = 80
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsm         #= TRS-80 Model 4,4P Montezuma System 710K - DSDD 96 tpi 5.25"
+  seclen 256         #= Sectors xx,256
+  tracks 160         #= (Cylinders * Sides) = 80*2 = 160
+#  sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 18          #= Sectors 18,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsn         #= TRS-80 Model 4,4P Montezuma Data 800K - DSDD 96 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 160         #= (Cylinders * Sides) = 80*2 = 160
+#  sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 0             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trso         #= TRS-80 Model 4,4P Montezuma Extend System 190K - SSDD 48 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 40          #= (Cylinders * Sides) = 40*1 = 40
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try x
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsp         #= TRS-80 Model 4,4P Montezuma Extend System 390K - DSDD 48 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 80          #= (Cylinders * Sides) = 40*2 = 80
+#  sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsq         #= TRS-80 Model 4,4P Montezuma Extend System 390K - SSDD 96 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 80          #= (Cylinders * Sides) = 80*1 = 80
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsr         #= TRS-80 Model 4,4P Montezuma Extend System 790K - DSDD 96 tpi 5.25"
+  seclen 512         #= Sectors xx,512
+  tracks 160         #= (Cylinders * Sides) = 80*2 = 160
+#  sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 2          #= OFS = 2
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trss         #= TRS-80 Model 4,4P Montezuma Super Data 220K - SSDD 48 tpi 5.25"
+  seclen 1024        #= Sectors xx,1024
+  tracks 40          #= (Cylinders * Sides) = 40*1 = 40
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 6           #= Sectors 6,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trst         #= TRS-80 Model 4,4P Montezuma Super Data 440K - DSDD 48 tpi 5.25"
+  seclen 1024        #= Sectors xx,1024
+  tracks 80          #= (Cylinders * Sides) = 40*2 = 80
+#  sides outout       #= Order of Cylinders  = alt, outout, outback
+  sectrk 6           #= Sectors 6,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsu         #= TRS-80 Model 4,4P Montezuma Super Data 440K - SSDD 96 tpi 5.25"
+  seclen 1024        #= Sectors xx,1024
+  tracks 80          #= (Cylinders * Sides) = 80*1 = 80
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 6           #= Sectors 6,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsv         #= TRS-80 Model 4,4P Montezuma Super Data 880K - DSDD 96 tpi 5.25"
+  seclen 1024        #= Sectors xx,1024
+  tracks 160         #= (Cylinders * Sides) = 80*2 = 160
+#  sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 6           #= Sectors 6,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try x
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+diskdef trsw         #= TRS-80 Model 4,4P Montezuma System 400K - SSDD 96 tpi 3.5"
+  seclen 512         #= Sectors xx,512
+  tracks 80          #= (Cylinders * Sides) = 80*1 = 80
+# sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 10          #= Sectors 10,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+#  datarate DD        #= DENSITY SD, DD, HD, or ED
+#  FM NO              #= Format YES = FM, or NO = MFM
+  skew 2             #= [0..8] try 2
+  boottrk 0          #= OFS = 0
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+#BEGIN TRSE  TRS-80 II/12/16 Aton CP/M - SSHD 8" - 1024 x 8
+diskdef trse
+  seclen 1024
+  tracks 77
+  sectrk 8
+  blocksize 2048
+  maxdir 128
+  datarate DD
+  fm NO
+  skew 3
+  boottrk 0
+  offset 11520
+  os 2.2
+end
+
+# TRSF  TRS-80 II/12/16 Aton CP/M  - DSHD 8" - 1024 x 8
+diskdef trsf
+  seclen 1024
+  tracks 154
+  sides alt
+  sectrk 8
+  blocksize 2048
+  maxdir 192
+  skew 3
+  boottrk 0
+  offset 11520
+  os 2.2
+end
+
+# TRS5  TRS-80, Lifeboat CP/M (1024 bytes/sector) - SSDD 8"
+# The first track is 26 sectors with 128 bytes, the rest are 1024 x 8
+diskdef trs5
+  seclen 1024
+  tracks 75
+  sectrk 8
+  blocksize 2048
+  maxdir 128
+  skew 3
+  boottrk 0
+  os 2.2
+  offset 11520
 end
 
 # Memotech type 03, ie: 3.5" or 5.25", D/S, D/D, S/T
@@ -1411,5 +1720,102 @@ diskdef ampro800
   maxdir 256
   skew 0
   boottrk 2
+  os 2.2
+end
+
+# Ampro - DSDD 48 tpi 5.25" - 512 x 10
+diskdef ampro400d
+  seclen 512
+  tracks 80
+  sectrk 10
+  blocksize 2048
+  maxdir 128
+  skew 0
+  boottrk 2
+  os 2.2
+  libdsk:format ampro400d
+# DENSITY MFM ,LOW 
+# BSH 4 BLM 15 EXM 1 DSM 194 DRM 127 AL0 0C0H AL1 0 OFS 2
+end
+
+# BEGIN ampdsdd80  Ampro - DSDD 96 tpi 5.25" - 512 x 10
+# Test OK - image size = 819,200, from Don Maslin's archive
+diskdef ampdsdd80
+  seclen 1024
+  tracks 160
+  sectrk 5
+  blocksize 2048
+  maxdir 128
+  skew 0
+  boottrk 2
+  os 2.2
+  libdsk:format ampro800
+# DENSITY MFM ,LOW 
+# BSH 4 BLM 15 EXM 1 DSM 194 DRM 127 AL0 0C0H AL1 0 OFS 2
+end
+
+# ALTAIRZ80 SIMH *dsk 8MB Harddisk (Type AZ80 HDSK)
+diskdef 8megAltairSIMH
+  seclen 128
+  tracks 2048
+  sectrk 32
+  blocksize 4096
+  maxdir 1024
+  skew 0
+  boottrk 6
+  os 2.2
+end
+
+# ALTAIRZ80 SIMH *dsk MITS 88-DISK 137 Byte/Sektor
+# speedball (copylib) skewtable
+diskdef simh
+  seclen 128
+  tracks 254
+  sectrk 32
+  blocksize 2048
+  maxdir 256
+  skew 17
+  boottrk 6
+  os 2.2
+end
+
+diskdef all1         #= Allen-Bradley Advisor+ - DSDD 3.5"
+  seclen 512         #= Sectors xx,512
+  tracks 160         #= (Cylinders * Sides) = 80*2 = 160
+  sides alt          #= Order of Cylinders  = alt, outout, outback
+  sectrk 8           #= Sectors 8,xxx
+  blocksize 2048     #= (128*(BLM+1)) =  7=1024, 15=2048, 31=4096, 63=8192
+  maxdir 128         #= (DRM+1) = 128
+  datarate DD        #= DENSITY SD, DD, HD, or ED
+  FM NO              #= Format YES = FM, or NO = MFM
+  skew 0             #= [0..8] try x
+  boottrk 1          #= OFS = 1
+#                    #= 2, 2.2, or 3 (NO comment on next line)
+  os 2.2
+end
+
+# COM8  Compupro (Viasyn) 8/16 - SSDD 8" - 1024 x 8
+# IMD RAW format
+diskdef com8
+  seclen 1024
+  tracks 77
+  sectrk 8
+  blocksize 2048
+  maxdir 128
+  skew 3
+  offset 11520
+  boottrk 0
+  os 2.2
+end
+
+# Spectravideo SVI-728 (MSX) with SVI-707 floppy drive
+diskdef svi707
+  seclen 256
+  tracks 40
+  sectrk 17
+  blocksize 2048
+  maxdir 64
+  skew 0
+  boottrk 3
   os 2.2
 end

--- a/diskdefs.5
+++ b/diskdefs.5
@@ -1,0 +1,40 @@
+.\" Believe it or not, reportedly there are nroffs which do not know \(en
+.if n .ds en -
+.if t .ds en \(en
+.TH DISKDEFS 5 "Jan 23, 2019" "CP/M tools" "File formats"
+.SH NAME \"{{{roff}}}\"{{{
+diskdefs \- CP/M disk and file system format definitions
+.\"}}}
+.SH DESCRIPTION \"{{{
+The diskdefs file contains CP/M format descriptions,
+because CP/M in general does not store those in the file system and there are
+no standards of any kind.
+.PP
+A diskdefs file consists of one or more entries of the format:
+.PP
+.nf
+.RS
+\fBdiskdef\fP \fIname\fP
+  \fBseclen\fP \fIsize\fP
+  \fBtracks\fP \fIcount\fP
+  \fBsectrk\fP \fIcount\fP
+  \fBblocksize\fP \fIsize\fP
+  \fBmaxdir\fP \fIcount\fP
+  \fBboottrk\fP \fInumber\fP
+  [\fBskew\fP \fInumber\fP]
+  [\fBskewtab\fP \fIsector\fP[\fB,\fP\fIsector\fP]...]
+  [\fBos\fP \fB2.2\fP|\fB3\fP|\fBisx\fP|\fBp2dos\fP|\fBzsys\fP]
+  [\fBoffset\fP \fIsize\fP]
+  [\fBlogicalextents\fP \fIcount\fP]
+  [\fBlibdsk:format\fP \fIname\fP]
+\fBend\fP
+.RE
+.fi
+.PP
+\fBskew\fP and \fBskewtab\fP must only be used exclusively.
+.PP
+Comments are marked with a leading hash or semicolon and extend to the end of the line.
+.\"}}}
+.SH "SEE ALSO" \"{{{
+.IR cpm (5)
+.\"}}}

--- a/diskdefs.5.in
+++ b/diskdefs.5.in
@@ -1,0 +1,40 @@
+.\" Believe it or not, reportedly there are nroffs which do not know \(en
+.if n .ds en -
+.if t .ds en \(en
+.TH DISKDEFS 5 "@UPDATED@" "CP/M tools" "File formats"
+.SH NAME \"{{{roff}}}\"{{{
+diskdefs \- CP/M disk and file system format definitions
+.\"}}}
+.SH DESCRIPTION \"{{{
+The diskdefs file contains CP/M format descriptions,
+because CP/M in general does not store those in the file system and there are
+no standards of any kind.
+.PP
+A diskdefs file consists of one or more entries of the format:
+.PP
+.nf
+.RS
+\fBdiskdef\fP \fIname\fP
+  \fBseclen\fP \fIsize\fP
+  \fBtracks\fP \fIcount\fP
+  \fBsectrk\fP \fIcount\fP
+  \fBblocksize\fP \fIsize\fP
+  \fBmaxdir\fP \fIcount\fP
+  \fBboottrk\fP \fInumber\fP
+  [\fBskew\fP \fInumber\fP]
+  [\fBskewtab\fP \fIsector\fP[\fB,\fP\fIsector\fP]...]
+  [\fBos\fP \fB2.2\fP|\fB3\fP|\fBisx\fP|\fBp2dos\fP|\fBzsys\fP]
+  [\fBoffset\fP \fIsize\fP]
+  [\fBlogicalextents\fP \fIcount\fP]
+  [\fBlibdsk:format\fP \fIname\fP]
+\fBend\fP
+.RE
+.fi
+.PP
+\fBskew\fP and \fBskewtab\fP must only be used exclusively.
+.PP
+Comments are marked with a leading hash or semicolon and extend to the end of the line.
+.\"}}}
+.SH "SEE ALSO" \"{{{
+.IR cpm (5)
+.\"}}}

--- a/fsck.cpm.1
+++ b/fsck.cpm.1
@@ -1,4 +1,4 @@
-.TH FSCK.CPM 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH FSCK.CPM 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME ..\"{{{roff}}}\"{{{
 fsck.cpm \- check a CP/M file system
 .\"}}}

--- a/fsck.cpm.1.in
+++ b/fsck.cpm.1.in
@@ -1,8 +1,8 @@
 .TH FSCK.CPM 1 "@UPDATED@" "CP/M tools" "User commands"
-.SH NAME \"{{{roff}}}\"{{{
+.SH NAME ..\"{{{roff}}}\"{{{
 fsck.cpm \- check a CP/M file system
 .\"}}}
-.SH SYNOPSIS \"{{{
+.SH SYNOPSIS .\"{{{
 .ad l
 .B fsck.cpm
 .RB [ \-f
@@ -11,7 +11,7 @@ fsck.cpm \- check a CP/M file system
 .I image
 .ad b
 .\"}}}
-.SH DESCRIPTION \"{{{
+.SH DESCRIPTION .\"{{{
 \fBfsck.cpm\fP is used to check and repair a CP/M file system.  After
 reading the directory, it makes two passes.  The first pass checks extent
 fields for range and format violations (bad status, extent number, last
@@ -22,7 +22,7 @@ invalid time stamp mode).  The second pass checks extent connectivity
 .P
 \fBfsck.cpm\fP can not yet repair all errors.
 .\"}}}
-.SH OPTIONS \"{{{
+.SH OPTIONS .\"{{{
 .IP "\fB\-f\fP \fIformat\fP"
 Use the given CP/M disk \fIformat\fP instead of the default format.
 .IP "\fB\-T\fP \fIlibdsk-type\fP"
@@ -31,19 +31,19 @@ libdsk driver type, e.g. \fBtele\fP for Teledisk images or \fBraw\fP for raw ima
 .IP "\fB\-n\fP"
 Open the file system read-only and do not repair any errors.
 .\"}}}
-.SH "RETURN VALUE" \"{{{
+.SH "RETURN VALUE" .\"{{{
 Upon successful completion, exit code 0 is returned.
 .\"}}}
-.SH ERRORS \"{{{
+.SH ERRORS .\"{{{
 Any errors are indicated by exit code 1.
 .\"}}}
-.SH FILES \"{{{
+.SH FILES .\"{{{
 @DATADIR@/diskdefs	CP/M disk format definitions
 .\"}}}
 .SH ENVIRONMENT \"{{{
 CPMTOOLSFMT     Default format
 .\"}}}
-.SH DIAGNOSTICS \"{{{
+.SH DIAGNOSTICS .\"{{{
 .IP "\fIimage\fP: \fIused\fP/\fItotal\fP files (\fIn\fP.\fIn\fP% non-contiguos), \fIused\fP/\fItotal\fP blocks"
 No inconsistencies could be found.  The number of used files actually
 is the number of used extents.  Since a file may use more than
@@ -54,7 +54,7 @@ pointed to by the same extent do not have sequential block numbers.
 The number of used blocks includes the blocks used for system tracks
 and the directory.
 .\"}}}
-.SH AUTHORS \"{{{
+.SH AUTHORS .\"{{{
 This program is copyright 1997\(en2012 Michael Haardt
 <michael@moria.de>.  The Windows port is copyright 2000, 2001, 2011 John Elliott
 <jce@seasip.demon.co.uk>.
@@ -73,7 +73,7 @@ You should have received a copy of the GNU General Public License along
 with this program.  If not, write to the Free Software Foundation, Inc.,
 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 .\"}}}
-.SH "SEE ALSO" \"{{{
+.SH "SEE ALSO" .\"{{{
 .IR fsck (8),
 .IR mkfs.cpm (1),
 .IR cpm (5)

--- a/fsed.cpm.1
+++ b/fsed.cpm.1
@@ -1,4 +1,4 @@
-.TH FSED.CPM 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH FSED.CPM 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME ..\"{{{roff}}}\"{{{
 fsed.cpm \- edit a CP/M file system
 .\"}}}

--- a/fsed.cpm.1.in
+++ b/fsed.cpm.1.in
@@ -1,8 +1,8 @@
 .TH FSED.CPM 1 "@UPDATED@" "CP/M tools" "User commands"
-.SH NAME \"{{{roff}}}\"{{{
+.SH NAME ..\"{{{roff}}}\"{{{
 fsed.cpm \- edit a CP/M file system
 .\"}}}
-.SH SYNOPSIS \"{{{
+.SH SYNOPSIS .\"{{{
 .ad l
 .B fsed.cpm
 .RB [ \-f
@@ -10,29 +10,29 @@ fsed.cpm \- edit a CP/M file system
 .I image
 .ad b
 .\"}}}
-.SH DESCRIPTION \"{{{
+.SH DESCRIPTION .\"{{{
 \fBfsed.cpm\fP edits a CP/M file system on an image file or device.
 It knows about the system, directory and data area, using sector skew on
 the last two.  Directory entries are decoded.  The interactive usage is
 self-explanatory.
 .\"}}}
-.SH OPTIONS \"{{{
+.SH OPTIONS .\"{{{
 .IP "\fB\-f\fP \fIformat\fP"
 Use the given CP/M disk \fIformat\fP instead of the default format.
 .IP "\fB\-T\fP \fIlibdsk-type\fP"
 libdsk driver type, e.g. \fBtele\fP for Teledisk images or \fBraw\fP for raw images 
 (requires building cpmtools with support for libdsk).
 .\"}}}
-.SH "RETURN VALUE" \"{{{
+.SH "RETURN VALUE" .\"{{{
 Upon successful completion, exit code 0 is returned.
 .\"}}}
-.SH ERRORS \"{{{
+.SH ERRORS .\"{{{
 Any errors are indicated by exit code 1.
 .\"}}}
 .SH ENVIRONMENT \"{{{
 CPMTOOLSFMT     Default format
 .\"}}}
-.SH FILES \"{{{
+.SH FILES .\"{{{
 @DATADIR@/diskdefs	CP/M disk format definitions
 .\"}}}
 .SH AUTHORS \"{{{
@@ -54,7 +54,7 @@ You should have received a copy of the GNU General Public License along
 with this program.  If not, write to the Free Software Foundation, Inc.,
 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 .\"}}}
-.SH "SEE ALSO" \"{{{
+.SH "SEE ALSO" .\"{{{
 .IR fsck.cpm (1),
 .IR mkfs.cpm (1),
 .IR cpmls (1),

--- a/fsed.cpm.c
+++ b/fsed.cpm.c
@@ -160,7 +160,7 @@ static void data(struct cpmSuperBlock *sb, const char *buf, unsigned long int po
   {
     move(4+(i>>4),(i&0x0f)*3+!!(i&0x8)); printw("%02x",buf[i+offset]&0xff);
     if (pos%sb->secLength==i+offset) attron(A_REVERSE);
-    move(4+(i>>4),50+(i&0x0f)); printw("%c",isprint(buf[i+offset]) ? buf[i+offset] : '.');
+    move(4+(i>>4),50+(i&0x0f)); printw("%c",isprint((unsigned char)buf[i+offset]) ? buf[i+offset] : '.');
     attroff(A_REVERSE);
   }
   move(4+((pos&0x7f)>>4),((pos&0x7f)&0x0f)*3+!!((pos&0x7f)&0x8)+1);

--- a/mkfs.cpm.1
+++ b/mkfs.cpm.1
@@ -1,4 +1,4 @@
-.TH MKFS.CPM 1 "October 25, 2014" "CP/M tools" "User commands"
+.TH MKFS.CPM 1 "Jan 23, 2019" "CP/M tools" "User commands"
 .SH NAME \"{{{roff}}}\"{{{
 mkfs.cpm \- make a CP/M file system
 .\"}}}


### PR DESCRIPTION
CP/M 2.2 allowed user numbers up to 31, while CP/M 3 still worked with those but limited normal access to 0-15. Without this fix to cpmfs.h, using cpmtools on images classified as "os 2.2" with user numbers between 15 and 31 will corrupt the disk, by re-using blocks already allocated to those files.