### PR TITLE
Add Intel MDS 8" disk formats

### DIFF
--- a/diskdefs
+++ b/diskdefs
@@ -1851,3 +1851,27 @@ diskdef svi707
   boottrk 3
   os 2.2
 end
+
+# Intel MDS/22 8" Double Density
+diskdef mds-dd
+  seclen 128
+  tracks 77
+  sectrk 52
+  blocksize 2048
+  maxdir 128
+  skew 0
+  boottrk 2
+  os 2.2
+end
+
+# Intel MDS/22 8" Single Density. Untested.
+diskdef mds-sd
+  seclen 128
+  tracks 77
+  sectrk 26
+  blocksize 1024
+  maxdir 64
+  skew 0
+  boottrk 2
+  os 2.2
+end


### PR DESCRIPTION
I had some Intel MDS 8" floppy disks in CP/M format. The double density diskdef I created allowed me to extract the files from the disks. I also attempted to create a single density version from information I found but I didn't have any disks in that format to test. If you only want tested formats just take the double density format.