### PR TITLE
Cpmtools 2.21 new

### DIFF
--- a/cpmcp.1
+++ b/cpmcp.1
@@ -16,7 +16,10 @@ cpmcp \- copy files from and to CP/M disks
 .RB [ \-f
 .IR format ]
 .RB [ \-p ]
+.RB [ \-s
+.IR c ]
 .RB [ \-t ]
+.RB [ \-u ]
 .I image
 \fIuser\fP\fB:\fP\fIfile\fP ... \fIdirectory\fP
 .br
@@ -32,6 +35,8 @@ cpmcp \- copy files from and to CP/M disks
 .RB [ \-f
 .IR format ]
 .RB [ \-p ]
+.RB [ \-s
+.IR c ]
 .RB [ \-t ]
 .I image
 \fIfile\fP ... \fIuser\fP\fB:\fP
@@ -58,8 +63,14 @@ libdsk driver type, e.g. \fBtele\fP for Teledisk images or \fBraw\fP for raw ima
 .IP \fB\-p\fP
 Preserve time stamps when copying files from CP/M to UNIX (not
 implemented for copying the other way so far).
+.IP "\fB\-s\fP \fIc\fP"
+Replace slashes ('/') in CP/M names with character 'c' in host file names,
+and perform the reverse translation when creating CP/M file names.
 .IP \fB\-t\fP
 Convert text files between CP/M and UNIX conventions.
+.IP \fB\-u\fP
+Use upper-case letters for host file names, instead of the normal
+translation to lower-case.
 .\"}}}
 .SH "RETURN VALUE" \"{{{
 Upon successful completion, exit code 0 is returned.

--- a/cpmcp.1.in
+++ b/cpmcp.1.in
@@ -16,7 +16,10 @@ cpmcp \- copy files from and to CP/M disks
 .RB [ \-f
 .IR format ]
 .RB [ \-p ]
+.RB [ \-s
+.IR c ]
 .RB [ \-t ]
+.RB [ \-u ]
 .I image
 \fIuser\fP\fB:\fP\fIfile\fP ... \fIdirectory\fP
 .br
@@ -32,6 +35,8 @@ cpmcp \- copy files from and to CP/M disks
 .RB [ \-f
 .IR format ]
 .RB [ \-p ]
+.RB [ \-s
+.IR c ]
 .RB [ \-t ]
 .I image
 \fIfile\fP ... \fIuser\fP\fB:\fP
@@ -58,8 +63,14 @@ libdsk driver type, e.g. \fBtele\fP for Teledisk images or \fBraw\fP for raw ima
 .IP \fB\-p\fP
 Preserve time stamps when copying files from CP/M to UNIX (not
 implemented for copying the other way so far).
+.IP "\fB\-s\fP \fIc\fP"
+Replace slashes ('/') in CP/M names with character 'c' in host file names,
+and perform the reverse translation when creating CP/M file names.
 .IP \fB\-t\fP
 Convert text files between CP/M and UNIX conventions.
+.IP \fB\-u\fP
+Use upper-case letters for host file names, instead of the normal
+translation to lower-case.
 .\"}}}
 .SH "RETURN VALUE" \"{{{
 Upon successful completion, exit code 0 is returned.

--- a/cpmfs.h
+++ b/cpmfs.h
@@ -142,6 +142,7 @@ struct cpmSuperBlock
   int sectrk;
   int blksiz;
   int maxdir;
+  int dirblks;
   int skew;
   int boottrk;
   off_t offset;

--- a/cpmls.c
+++ b/cpmls.c
@@ -61,7 +61,7 @@ static void olddir(char **dirent, int entries)
 	putchar('\n');
     }
 
-    if (announce==2) announce=1;
+    announce=1;
   }
   if (entries==0) printf("No files\n");
 }

--- a/diskdefs
+++ b/diskdefs
@@ -324,6 +324,7 @@ diskdef kpii
   sectrk 10
   blocksize 1024
   maxdir 64
+  dirblks 4
   skew 0
   boottrk 1
   os 2.2
@@ -337,6 +338,7 @@ diskdef kpiv
   sectrk 10
   blocksize 2048
   maxdir 64
+  dirblks 2
   skew 0
   boottrk 1
   os 2.2

--- a/diskdefs.5
+++ b/diskdefs.5
@@ -20,6 +20,7 @@ A diskdefs file consists of one or more entries of the format:
   \fBsectrk\fP \fIcount\fP
   \fBblocksize\fP \fIsize\fP
   \fBmaxdir\fP \fIcount\fP
+  \fBdirblks\fP \fIcount\fP
   \fBboottrk\fP \fInumber\fP
   [\fBskew\fP \fInumber\fP]
   [\fBskewtab\fP \fIsector\fP[\fB,\fP\fIsector\fP]...]
@@ -34,6 +35,12 @@ A diskdefs file consists of one or more entries of the format:
 \fBskew\fP and \fBskewtab\fP must only be used exclusively.
 .PP
 Comments are marked with a leading hash or semicolon and extend to the end of the line.
+.PP
+\fBmaxdir\fP and \fBdirblks\fP are both used in cases where the vendor
+used an inflated DPB ALV0 to reserve space on the disk beyond \fBmaxdir\fP.
+Without special treatment, cpmtools will destroy that reserved data.
+If only one is specified, the other is computed assuming both represent the same
+amount of space.
 .\"}}}
 .SH "SEE ALSO" \"{{{
 .IR cpm (5)

--- a/diskdefs.5.in
+++ b/diskdefs.5.in
@@ -20,6 +20,7 @@ A diskdefs file consists of one or more entries of the format:
   \fBsectrk\fP \fIcount\fP
   \fBblocksize\fP \fIsize\fP
   \fBmaxdir\fP \fIcount\fP
+  \fBdirblks\fP \fIcount\fP
   \fBboottrk\fP \fInumber\fP
   [\fBskew\fP \fInumber\fP]
   [\fBskewtab\fP \fIsector\fP[\fB,\fP\fIsector\fP]...]
@@ -34,6 +35,12 @@ A diskdefs file consists of one or more entries of the format:
 \fBskew\fP and \fBskewtab\fP must only be used exclusively.
 .PP
 Comments are marked with a leading hash or semicolon and extend to the end of the line.
+.PP
+\fBmaxdir\fP and \fBdirblks\fP are both used in cases where the vendor
+used an inflated DPB ALV0 to reserve space on the disk beyond \fBmaxdir\fP.
+Without special treatment, cpmtools will destroy that reserved data.
+If only one is specified, the other is computed assuming both represent the same
+amount of space.
 .\"}}}
 .SH "SEE ALSO" \"{{{
 .IR cpm (5)

--- a/fsck.cpm.c
+++ b/fsck.cpm.c
@@ -240,7 +240,7 @@ static int fsck(struct cpmInode *root, const char *image)
       {
         int block,min,max,i;
 
-        min=(sb->maxdir*32+sb->blksiz-1)/sb->blksiz;
+        min=sb->dirblks;
         max=sb->size;
         for (i=0; i<16; ++i)
         {

--- a/fsed.cpm.c
+++ b/fsed.cpm.c
@@ -83,10 +83,11 @@ static void info(struct cpmSuperBlock *sb, const char *format, const char *image
 
   move(10,0);printw("                 Block size: %d",sb->blksiz);
   move(11,0);printw("Number of directory entries: %d",sb->maxdir);
-  move(12,0);printw("        Logical sector skew: %d",sb->skew);
-  move(13,0);printw("    Number of system tracks: %d",sb->boottrk);
-  move(14,0);printw(" Logical extents per extent: %d",sb->extents);
-  move(15,0);printw("    Allocatable data blocks: %d",sb->size-(sb->maxdir*32+sb->blksiz-1)/sb->blksiz);
+  move(12,0);printw(" Number of directory blocks: %d",sb->dirblks);
+  move(13,0);printw("        Logical sector skew: %d",sb->skew);
+  move(14,0);printw("    Number of system tracks: %d",sb->boottrk);
+  move(15,0);printw(" Logical extents per extent: %d",sb->extents);
+  move(16,0);printw("    Allocatable data blocks: %d",sb->size-sb->dirblks);
 
   msg="Any key to continue";
   move(23,(COLS-strlen(msg))/2); printw(msg);


### PR DESCRIPTION
Three new commits for consideration.

First adds options to cpmcp to use uppercase names on the host, and to handle '/' characters in CP/M filenames.

Second fixes a problem with Kaypro disks (possibly others) where the vendor reserved extra space after the directory, but cpmtools has only one concept of directory and pre-allocated space.

Third is a fix to "cpmls -d" where if a disk had no user-0 files then the first user number would not be labeled in the output, causing confusion.