### PR TITLE
Adding support for P2000C/P2012 5.25" DS/DD images

### DIFF
--- a/diskdefs
+++ b/diskdefs
@@ -1875,3 +1875,16 @@ diskdef mds-sd
   boottrk 2
   os 2.2
 end
+
+# P2000C P2012 disk format
+# 5.25" disk DS/DD
+diskdef p2000c
+  seclen 128
+  tracks 80
+  sectrk 16
+  blocksize 4096
+  maxdir 128
+  skew 0
+  boottrk 4
+  os 2.2
+end

--- a/diskdefs
+++ b/diskdefs
@@ -1879,12 +1879,12 @@ end
 # P2000C P2012 disk format
 # 5.25" disk DS/DD
 diskdef p2000c
-  seclen 256
+  seclen 128
   tracks 80
-  sectrk 8
+  sectrk 32
   blocksize 4096
   maxdir 128
-  skew 2
-  boottrk 4
+  boottrk 2
+  skewtab 0 1 4 5 8 9 12 13 16 17 20 21 24 25 28 29 2 3 6 7 10 11 14 15 18 19 22 23 26 27 30 31
   os 2.2
 end

--- a/diskdefs
+++ b/diskdefs
@@ -1879,12 +1879,12 @@ end
 # P2000C P2012 disk format
 # 5.25" disk DS/DD
 diskdef p2000c
-  seclen 128
+  seclen 256
   tracks 80
-  sectrk 16
+  sectrk 8
   blocksize 4096
   maxdir 128
-  skew 0
+  skew 2
   boottrk 4
   os 2.2
 end


### PR DESCRIPTION
Philips P2000C (P2012 model) are not yet supported by CPMtools. This update adds an entry to `diskdefs` to provide support. 

To illustrate, the following command reads a disk image in the P2000C format.

```bash
cpmls -f p2000c disk01.img
```

I have tested the updated `diskdefs` file on a number of Philips P2000C images obtained from [this source](https://archive.org/download/UnRenamedFiles-Various/Philips%20P2000C%20files%20%5BTD0%5D.zip) with success.